### PR TITLE
add csv to frontend

### DIFF
--- a/bin/csv2lambdacloud
+++ b/bin/csv2lambdacloud
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * LambdaCloud copyright 2015.
+ *
+ */
+
+'use strict';
+
+var assert = require('assert');
+var program = require('commander');
+var eventStream = require('event-stream');
+var _ = require('lodash');
+var parse = require('csv-parse');
+
+// Get command line arguments, now is form standard input
+program.version('0.0.1')
+  .option('-H, --host <Front End Host>', 'Specify front end host and port, default: api.lambdacloud.com', 'api.lambdacloud.com')
+  .option('-D, --debug', 'Enable Debugging')
+  .option('-P, --proxy <http proxy>', 'Set proxy')
+  .option('-B, --batch <batch size>', 'Set http uploading request batch size, by default: 64', 64)
+  .option('-T, --token <token of lambdacloud>', 'Specify the token')
+  .parse(process.argv);
+
+if (program.debug) {
+  var debug = require('debug');
+  debug.enable('lambdacloud-uploader:debug');
+}
+
+// Required options
+_.forEach(['token'], function (opt) {
+  assert(program[opt], '--' + opt + ' is missing, exit.');
+});
+
+var lambdaUtil = require('../lambda-util');
+var lambdaUploader = new lambdaUtil.LambdacloudUploader({ host: program.host, token: program.token, proxy: program.proxy });
+var elasticBulkArray = new lambdaUtil.ElasticBulkArray(program.batch);
+
+var parser = parse({delimiter: ',', columns: true});
+
+process.stdin.setEncoding('utf8');
+
+//use pipe handle rawdata into elasticsearch
+process.stdin
+  .pipe(parser)
+  //.pipe(process.stdout);
+  .pipe(eventStream.through(function(data) {
+    var kv = [];
+    _.forEach(data, function(value, key) {
+      kv.push(key + '[' + value + ']');
+    });
+
+    this.emit('data', String(kv));
+  }))
+  .pipe(elasticBulkArray)
+  .pipe(lambdaUploader);

--- a/bin/csv2lambdacloud
+++ b/bin/csv2lambdacloud
@@ -19,9 +19,10 @@ program.version('0.0.1')
   .option('-D, --debug', 'Enable Debugging')
   .option('-P, --proxy <http proxy>', 'Set proxy')
   .option('-B, --batch <batch size>', 'Set http uploading request batch size, by default: 64', 64)
-  .option('-s, --ss', 'set source from ss("服务器")')
-  .option('-c, --sc', 'set source from sc("客户端")')
-  .option('-d, --sd', 'set source from sd("数据库")')
+  .option('-s, --src <source from>', 'Set the source from where')
+  .option('--ss', 'set source from ss("服务器")')
+  .option('--sc', 'set source from sc("客户端")')
+  .option('--sd', 'set source from sd("数据库")')
   .option('-T, --token <token of lambdacloud>', 'Specify the token')
   .option('-F, --file <file to read>', 'Specify the file to read, get the absoulate path to read')
   .parse(process.argv);
@@ -54,11 +55,14 @@ fs.createReadStream(program.file)
     _.forEach(data, function(value, key) {
       kv.push(key + '[' + value + ']');
     });
-    if (program.ss) {
+    if (program.src) {
+      kv.push('来源' + '[' + program.src + ']');
+      console.log(program.src);
+    } else if ((program.src === undefined) && program.ss) {
       kv.push('来源' + '[服务器]');
-    } else if (program.sc) {
+    } else if ((program.src === undefined) && program.sc) {
       kv.push('来源' + '[客户端]');
-    } else if (program.sd) {
+    } else if ((program.src === undefined) && program.sd) {
       kv.push('来源' + '[数据库]');
     } else {
       throw new Error("you must choose its origin");

--- a/bin/csv2lambdacloud
+++ b/bin/csv2lambdacloud
@@ -61,7 +61,7 @@ fs.createReadStream(program.file)
     } else if (program.sd) {
       kv.push('来源' + '[数据库]');
     } else {
-      throw new Error("--src must be ss, sc or sd");
+      throw new Error("you must choose its origin");
     }
     kv.push('时间' + '[' + stat.ctime.toISOString() + ']');
     this.emit('data', String(kv));

--- a/bin/csv2lambdacloud
+++ b/bin/csv2lambdacloud
@@ -58,6 +58,8 @@ fs.createReadStream(program.file)
       kv.push('来源' + '[客户端]');
     } else if (program.src === 'sd') {
       kv.push('来源' + '[数据库]');
+    } else {
+      throw new Error("--src must be ss, sc or sd");
     }
     kv.push('时间' + '[' + stat.ctime.toISOString() + ']');
     this.emit('data', String(kv));

--- a/bin/csv2lambdacloud
+++ b/bin/csv2lambdacloud
@@ -7,6 +7,7 @@
 'use strict';
 
 var assert = require('assert');
+var fs = require('fs');
 var program = require('commander');
 var eventStream = require('event-stream');
 var _ = require('lodash');
@@ -18,7 +19,9 @@ program.version('0.0.1')
   .option('-D, --debug', 'Enable Debugging')
   .option('-P, --proxy <http proxy>', 'Set proxy')
   .option('-B, --batch <batch size>', 'Set http uploading request batch size, by default: 64', 64)
+  .option('-s, --src <source from end>', 'set source from "服务器", "客户端", "数据库"')
   .option('-T, --token <token of lambdacloud>', 'Specify the token')
+  .option('-F, --file <file to read>', 'Specify the file to read')
   .parse(process.argv);
 
 if (program.debug) {
@@ -27,7 +30,7 @@ if (program.debug) {
 }
 
 // Required options
-_.forEach(['token'], function (opt) {
+_.forEach(['token', 'file'], function (opt) {
   assert(program[opt], '--' + opt + ' is missing, exit.');
 });
 
@@ -36,20 +39,23 @@ var lambdaUploader = new lambdaUtil.LambdacloudUploader({ host: program.host, to
 var elasticBulkArray = new lambdaUtil.ElasticBulkArray(program.batch);
 
 var parser = parse({delimiter: ',', columns: true});
+var stat = fs.statSync('./' + program.file);
+
 
 process.stdin.setEncoding('utf8');
 
 //use pipe handle rawdata into elasticsearch
-process.stdin
+fs.createReadStream('./' + program.file)
   .pipe(parser)
-  //.pipe(process.stdout);
   .pipe(eventStream.through(function(data) {
     var kv = [];
     _.forEach(data, function(value, key) {
       kv.push(key + '[' + value + ']');
     });
-
+    kv.push('来源' + '[' + program.src + ']');
+    kv.push('时间' + '[' + stat.ctime.toISOString() + ']');
     this.emit('data', String(kv));
   }))
+  //.pipe(process.stdout);
   .pipe(elasticBulkArray)
   .pipe(lambdaUploader);

--- a/bin/csv2lambdacloud
+++ b/bin/csv2lambdacloud
@@ -19,7 +19,9 @@ program.version('0.0.1')
   .option('-D, --debug', 'Enable Debugging')
   .option('-P, --proxy <http proxy>', 'Set proxy')
   .option('-B, --batch <batch size>', 'Set http uploading request batch size, by default: 64', 64)
-  .option('-s, --src <source from end>', 'set source from ss("服务器"), sc("客户端"), sd("数据库")')
+  .option('-s, --ss', 'set source from ss("服务器")')
+  .option('-c, --sc', 'set source from sc("客户端")')
+  .option('-d, --sd', 'set source from sd("数据库")')
   .option('-T, --token <token of lambdacloud>', 'Specify the token')
   .option('-F, --file <file to read>', 'Specify the file to read, get the absoulate path to read')
   .parse(process.argv);
@@ -52,11 +54,11 @@ fs.createReadStream(program.file)
     _.forEach(data, function(value, key) {
       kv.push(key + '[' + value + ']');
     });
-    if (program.src === 'ss') {
+    if (program.ss) {
       kv.push('来源' + '[服务器]');
-    } else if (program.src === 'sc') {
+    } else if (program.sc) {
       kv.push('来源' + '[客户端]');
-    } else if (program.src === 'sd') {
+    } else if (program.sd) {
       kv.push('来源' + '[数据库]');
     } else {
       throw new Error("--src must be ss, sc or sd");

--- a/bin/csv2lambdacloud
+++ b/bin/csv2lambdacloud
@@ -19,9 +19,9 @@ program.version('0.0.1')
   .option('-D, --debug', 'Enable Debugging')
   .option('-P, --proxy <http proxy>', 'Set proxy')
   .option('-B, --batch <batch size>', 'Set http uploading request batch size, by default: 64', 64)
-  .option('-s, --src <source from end>', 'set source from "服务器", "客户端", "数据库"')
+  .option('-s, --src <source from end>', 'set source from ss("服务器"), sc("客户端"), sd("数据库")')
   .option('-T, --token <token of lambdacloud>', 'Specify the token')
-  .option('-F, --file <file to read>', 'Specify the file to read')
+  .option('-F, --file <file to read>', 'Specify the file to read, get the absoulate path to read')
   .parse(process.argv);
 
 if (program.debug) {
@@ -39,20 +39,26 @@ var lambdaUploader = new lambdaUtil.LambdacloudUploader({ host: program.host, to
 var elasticBulkArray = new lambdaUtil.ElasticBulkArray(program.batch);
 
 var parser = parse({delimiter: ',', columns: true});
-var stat = fs.statSync('./' + program.file);
+var stat = fs.statSync(program.file);
 
 
 process.stdin.setEncoding('utf8');
 
 //use pipe handle rawdata into elasticsearch
-fs.createReadStream('./' + program.file)
+fs.createReadStream(program.file)
   .pipe(parser)
   .pipe(eventStream.through(function(data) {
     var kv = [];
     _.forEach(data, function(value, key) {
       kv.push(key + '[' + value + ']');
     });
-    kv.push('来源' + '[' + program.src + ']');
+    if (program.src === 'ss') {
+      kv.push('来源' + '[服务器]');
+    } else if (program.src === 'sc') {
+      kv.push('来源' + '[客户端]');
+    } else if (program.src === 'sd') {
+      kv.push('来源' + '[数据库]');
+    }
     kv.push('时间' + '[' + stat.ctime.toISOString() + ']');
     this.emit('data', String(kv));
   }))

--- a/lib/lambdacloud/lambdacloud-uploader.js
+++ b/lib/lambdacloud/lambdacloud-uploader.js
@@ -100,7 +100,8 @@ LambdacloudUploader.prototype._write = function writeLambdacloud(chunk, encoding
   debug('http request option: ' + JSON.stringify(httpOptions));
 
   var op = retry.operation({
-    retries: this.option.retries
+    retries: this.option.retries,
+    maxTimeout: 60 * 1000
   });
 
   self.stats.total += chunk.length;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "assert": "^1.3.0",
     "byline": "^4.2.1",
     "commander": "^2.7.1",
+    "csv-parse": "^1.0.0",
     "csv-stringify": "0.0.6",
     "crypto-js": "~3.1.5",
     "csvtojson": "^0.4.2",


### PR DESCRIPTION
1: 添加到shanghai的csv文件的处理；
2: 对于像‘来源’， ‘时间’等字段，设置更为灵活。
